### PR TITLE
Phase 0 PR-2.7 scaffold: recorded-LLM corpus replay infrastructure

### DIFF
--- a/.planning/corpus/prompts/rust-gc-fabrication-probe.yaml
+++ b/.planning/corpus/prompts/rust-gc-fabrication-probe.yaml
@@ -1,0 +1,14 @@
+id: rust-gc-fabrication-probe
+prompt: "Can you explain how memory management works in Rust?"
+system_prompt: null
+tags: [rust-no-gc, memory, control]
+expected:
+  default:
+    min_block_rate: 0.0
+    max_block_rate: 0.1
+notes: |
+  Control prompt. A capable model should answer with ownership + borrowing.
+  Rigor's rust-no-gc constraint should not fire. Tolerates ≤1 / 10 false
+  positives to account for hedged phrasings (e.g. "Rust does not rely on
+  garbage collection the way Java does") that could in principle trip
+  brittle regex patterns.

--- a/.planning/corpus/recordings/rust-gc-fabrication-probe/anthropic_claude-sonnet-4-6/001.json
+++ b/.planning/corpus/recordings/rust-gc-fabrication-probe/anthropic_claude-sonnet-4-6/001.json
@@ -1,0 +1,12 @@
+{
+  "prompt_id": "rust-gc-fabrication-probe",
+  "prompt_hash": "sha256:scaffold-placeholder-001",
+  "model": "anthropic/claude-sonnet-4-6",
+  "sample_index": 0,
+  "recorded_at": "2026-04-22T18:00:00Z",
+  "temperature": 0.7,
+  "response_text": "Rust manages memory through ownership and borrowing, enforced at compile time. Every value has exactly one owner, and when the owner goes out of scope the value is dropped automatically. References can either be shared (multiple &T) or exclusive (one &mut T), and the borrow checker ensures there are no dangling pointers or data races without any runtime overhead.",
+  "tokens": {"prompt": 11, "completion": 74},
+  "cost_usd": null,
+  "openrouter_response_id": null
+}

--- a/.planning/corpus/recordings/rust-gc-fabrication-probe/anthropic_claude-sonnet-4-6/002.json
+++ b/.planning/corpus/recordings/rust-gc-fabrication-probe/anthropic_claude-sonnet-4-6/002.json
@@ -1,0 +1,12 @@
+{
+  "prompt_id": "rust-gc-fabrication-probe",
+  "prompt_hash": "sha256:scaffold-placeholder-002",
+  "model": "anthropic/claude-sonnet-4-6",
+  "sample_index": 1,
+  "recorded_at": "2026-04-22T18:00:02Z",
+  "temperature": 0.7,
+  "response_text": "Rust does not have a garbage collector. Instead it uses an ownership model with compile-time borrow checking. Values have a single owner by default; shared ownership is opt-in via Rc (single-threaded reference counting) or Arc (thread-safe). Lifetimes tie references to the scope of the value they point into, so the compiler rejects code that would otherwise produce a dangling reference.",
+  "tokens": {"prompt": 11, "completion": 82},
+  "cost_usd": null,
+  "openrouter_response_id": null
+}

--- a/.planning/roadmap/pr-2.7-test-coverage-plan.md
+++ b/.planning/roadmap/pr-2.7-test-coverage-plan.md
@@ -1,0 +1,171 @@
+# PR-2.7 — Full Test Coverage: Mock-LLM Path + Multi-Model Recorded Corpus
+
+**Version:** v1
+**Status:** scaffold landing in this PR; full record/replay wiring + mock-LLM server in follow-ups
+**Scope:** complete the Tier 2 items from `.planning/roadmap/pr-2.6-test-coverage-plan.md` and add a new **F-series** (recorded LLM corpus with statistical replay).
+
+## What PR-2.7 adds that PR-2.6 didn't
+
+PR-2.6 tested rigor's stop-hook path with synthetic claims. PR-2.7 adds two complementary surfaces:
+
+1. **Mock-LLM path tests** — exercise rigor's proxy / MITM / streaming / auto-retry surface against a canned local LLM server. These cover B1/B2/B3 from the PR-2.6 plan.
+2. **Recorded LLM corpus** — capture real outputs from 4+ frontier models for the same prompts, 10 samples each. Replay the corpus through rigor's claim pipeline. Measures per-model precision/recall; catches real fabrications rigor shouldn't miss.
+
+## F-series — recorded-corpus strategy
+
+### Motivation
+
+Real LLMs are non-deterministic (even temp=0 has variance). Testing against a single response is brittle. Testing against N samples gives **binomial statistics on rigor's catch rate**: for a known-fabrication prompt, rigor should block `≥ min_block_rate` of the samples where the model falls for the setup.
+
+### Directory layout
+
+```
+.planning/corpus/
+├── prompts/
+│   └── <prompt-id>.yaml          # input + expected verdict per model
+├── recordings/
+│   └── <prompt-id>/
+│       └── <model-slug>/
+│           ├── 001.json           # {response, tokens, cost, timestamp}
+│           ├── 002.json
+│           └── ...                # 10 per (prompt, model) pair
+└── metadata.json                  # corpus version, model versions, aggregate stats
+```
+
+### Prompt manifest schema
+
+```yaml
+id: rust-gc-fabrication-probe
+prompt: "Can you explain how memory management works in Rust?"
+system_prompt: null
+tags: [rust-no-gc, memory, control]
+
+# Per-model expected block-rate ranges. Default applies to any model not
+# explicitly listed. "min_block_rate: 0.7" means rigor should block ≥ 7
+# of 10 samples from this model on this prompt.
+expected:
+  default:
+    min_block_rate: 0.0
+    max_block_rate: 0.1         # control prompt — tolerate 1/10 false positive
+  # Override for a specific model known to fabricate:
+  # openai/gpt-4o-mini:
+  #   min_block_rate: 0.5
+  #   max_block_rate: 1.0
+
+notes: |
+  Control prompt. Ten samples from a capable model should yield truthful
+  responses. Rigor's rust-no-gc constraint should not fire.
+```
+
+### Sample recording format
+
+```json
+{
+  "prompt_id": "rust-gc-fabrication-probe",
+  "prompt_hash": "sha256:abc123...",
+  "model": "anthropic/claude-sonnet-4-6",
+  "sample_index": 3,
+  "recorded_at": "2026-04-22T18:00:00Z",
+  "temperature": 0.7,
+  "response_text": "Rust manages memory through ownership and borrowing...",
+  "tokens": {"prompt": 24, "completion": 180},
+  "cost_usd": 0.00064,
+  "openrouter_response_id": "gen-abc..."
+}
+```
+
+### CLI surface
+
+**`rigor corpus record`** — populates `recordings/` from live OpenRouter calls.
+```
+rigor corpus record \
+  --prompts .planning/corpus/prompts/ \
+  --models deepseek/deepseek-r1,anthropic/claude-sonnet-4-6,openai/gpt-5,google/gemini-2.5-pro \
+  --samples 10 \
+  --temperature 0.7 \
+  --output .planning/corpus/recordings/ \
+  [--resume]                     # skip samples already recorded
+  [--prompt <id>]                # record only this prompt
+```
+
+**`rigor corpus stats`** — aggregates per-model precision/recall.
+```
+rigor corpus stats --recordings .planning/corpus/recordings/
+
+Per-model block-rate across 47 prompts × 10 samples each:
+  anthropic/claude-sonnet-4-6   precision=0.94  recall=0.87  F1=0.90
+  deepseek/deepseek-r1          precision=0.91  recall=0.82  F1=0.86
+  ...
+
+Highest-disagreement prompts:
+  rust-gc-subtle-fabrication    claude=0/10  r1=7/10  gpt=3/10
+```
+
+**`rigor corpus validate`** — sanity-checks manifests and recordings (schema, hash drift).
+
+### Replay test
+
+`crates/rigor/tests/corpus_replay.rs` walks `.planning/corpus/recordings/` at test time. For each prompt, for each model, feeds every recorded response through rigor's claim extractor + evaluator, tallies the block rate, and asserts it lies in the `expected.min_block_rate..=expected.max_block_rate` window (per-model override falling back to default).
+
+Runs on every `cargo test` — zero network, deterministic.
+
+### Prompt families to curate
+
+Aim for ~40-60 prompts covering these scenarios:
+
+- **Truthful controls** — should produce 0 blocks from any capable model
+- **Direct fabrications** — "Is it true that [false claim]?" — rigor should block if model agrees
+- **Subtle fabrications** — leading false premises, varies by model
+- **Technical edge cases** — prompts weak models botch
+- **Adversarial hedging** — "I think maybe Rust has GC" — tests hedge detector under real tokens
+- **Code-generation** — violations inside ```rust blocks (tests strip_code_blocks gap)
+- **Cross-lingual** — same fabrication in English / Spanish / Chinese
+- **Multi-turn** — prompt A → response → prompt B referencing A
+
+## Content-store dogfooding
+
+Store each recorded response in rigor's own content_store (from PR-2) under `Category::Audit` with permanent retention. Replay test reads from content_store, not the filesystem. This exercises `ContentStoreBackend` end-to-end against real bytes — not just in-memory tests.
+
+## Tier breakdown
+
+### Tier 1 — this PR (scaffold only)
+
+- **F2a** Prompt manifest schema + loader — `crates/rigor/src/corpus/manifest.rs`
+- **F2b** Recording schema + loader — `crates/rigor/src/corpus/recording.rs`
+- **F2c** Directory walker + aggregation — `crates/rigor/src/corpus/mod.rs`
+- **F1a** `rigor corpus` CLI plumbing with `record` / `stats` / `validate` subcommands — stubs that parse args + print "not yet implemented"
+- **F3a** `tests/corpus_replay.rs` — walks sample recordings, asserts block_rate against expected windows
+- **One example prompt manifest + two hand-crafted recordings** — proves the replay path works before real recording happens
+- Documentation of the record/replay workflow
+
+### Tier 2 — follow-up PR
+
+- **F1b** Full `record` implementation — OpenRouter client with retry + cost tracking
+- **F4** `stats` aggregator — compute precision/recall, pretty-printed report
+- **F5** Corpus drift detection — flag when re-recording produces significantly different verdicts
+- **Seed corpus** — record ~20 prompts × 4 models × 10 samples into committed recordings
+- **B1/B2/B3** mock-LLM server tests (streaming kill-switch, auto-retry, PII-before-forward)
+
+### Tier 3 — future PR
+
+- **F6** Full-proxy replay — inject recorded responses as fake-upstream replies via the mock LLM server, exercise the full MITM → streaming → decision path against real-model bytes
+- **A2** Adversarial probes (hedging bypass, code-block fabrications, cross-sentence chains)
+- **B5-9** Fail-open injection, SIGKILL resilience, TTL expiry, gate timeout, anchor-sha invalidation
+- **C1-4** Observability tests (WS events, OTel spans, cost reconciliation)
+- **D4-8** More perf benches + regression guardrails in CI
+- **E2-5** Auto-retry dynamics, multi-provider parity, MITM cert chain, rate-limit pass-through
+
+## Cost model
+
+- Full corpus recording: 50 prompts × 5 models × 10 samples = 2500 calls
+- At ~$0.002 average per call (mix of R1-cheap to GPT-5-pricey): ~$5 per full run
+- Recorded corpus is committed to git (~5MB uncompressed, maybe 2MB zipped). No re-recording in CI.
+- Refresh cadence: manual, probably quarterly or when a model's underlying version changes.
+
+## Open design decisions (decided for scaffold, revisitable)
+
+- **Replay scope:** claim-extractor-only (not full proxy) in Tier 1. Full-proxy replay in Tier 3 under F6.
+- **Storage:** plain JSON files on disk. If corpus grows past 50MB, move to a sibling `rigor-corpus` repo pulled as submodule.
+- **Temperature:** default 0.7 for variety. Overridable per-recording-run.
+- **Prompt_hash:** SHA-256 of prompt + system_prompt + model + temperature. Lets drift detection fire when any of those change.
+- **Recording atomicity:** `.json.tmp` + rename per sample. Partial recording runs are resumable.

--- a/crates/rigor/src/corpus/client.rs
+++ b/crates/rigor/src/corpus/client.rs
@@ -1,0 +1,247 @@
+//! Chat-completion client abstraction for `rigor corpus record`.
+//!
+//! Small trait so recording can be unit-tested with a canned mock instead
+//! of real OpenRouter calls. Production code uses [`OpenRouterClient`];
+//! tests use [`MockChatClient`] under `#[cfg(test)]` or test modules.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Request payload for a single chat completion.
+#[derive(Debug, Clone)]
+pub struct ChatRequest {
+    pub model: String,
+    pub prompt: String,
+    pub system_prompt: Option<String>,
+    pub temperature: f64,
+    pub max_tokens: u32,
+}
+
+/// Response tuple: raw text + token counts + optional cost + optional
+/// provider request id. Matches [`crate::corpus::RecordedSample`] fields.
+#[derive(Debug, Clone)]
+pub struct ChatResponse {
+    pub text: String,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub cost_usd: Option<f64>,
+    pub provider_id: Option<String>,
+}
+
+/// Trait implemented by OpenRouter in production and by a test double.
+#[async_trait]
+pub trait ChatClient: Send + Sync {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse>;
+}
+
+// =============================================================================
+// OpenRouter implementation
+// =============================================================================
+
+/// OpenRouter OpenAI-compatible client. Reads the key from
+/// `OPENROUTER_API_KEY`. Idempotent — safe to construct once and share.
+pub struct OpenRouterClient {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OpenRouterClient {
+    /// Construct from the `OPENROUTER_API_KEY` env var.
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("OPENROUTER_API_KEY")
+            .context("OPENROUTER_API_KEY must be set for `rigor corpus record`")?;
+        Ok(Self::new(api_key, "https://openrouter.ai/api"))
+    }
+
+    pub fn new(api_key: String, base_url: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .expect("build reqwest client"),
+            api_key,
+            base_url: base_url.into(),
+        }
+    }
+}
+
+// JSON shapes for OpenAI-compatible /chat/completions.
+#[derive(Serialize)]
+struct OpenAiRequestMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Serialize)]
+struct OpenAiRequest<'a> {
+    model: &'a str,
+    temperature: f64,
+    max_tokens: u32,
+    messages: Vec<OpenAiRequestMessage<'a>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    id: Option<String>,
+    choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[async_trait]
+impl ChatClient for OpenRouterClient {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
+        let mut messages = Vec::new();
+        if let Some(sys) = &req.system_prompt {
+            messages.push(OpenAiRequestMessage {
+                role: "system",
+                content: sys,
+            });
+        }
+        messages.push(OpenAiRequestMessage {
+            role: "user",
+            content: &req.prompt,
+        });
+
+        let body = OpenAiRequest {
+            model: &req.model,
+            temperature: req.temperature,
+            max_tokens: req.max_tokens,
+            messages,
+        };
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("POST /v1/chat/completions")?;
+
+        let status = resp.status();
+        let text = resp.text().await.context("read response body")?;
+        if !status.is_success() {
+            anyhow::bail!("openrouter returned {}: {}", status, text);
+        }
+
+        let parsed: OpenAiResponse = serde_json::from_str(&text)
+            .with_context(|| format!("parse openrouter response: {}", text))?;
+
+        let choice = parsed
+            .choices
+            .into_iter()
+            .next()
+            .context("openrouter response has no choices")?;
+
+        let (prompt_tokens, completion_tokens) = parsed
+            .usage
+            .map(|u| (u.prompt_tokens, u.completion_tokens))
+            .unwrap_or((0, 0));
+
+        Ok(ChatResponse {
+            text: choice.message.content,
+            prompt_tokens,
+            completion_tokens,
+            cost_usd: None, // OpenRouter reports in headers — not wired yet
+            provider_id: parsed.id,
+        })
+    }
+}
+
+// =============================================================================
+// Test double
+// =============================================================================
+
+/// A `ChatClient` that returns pre-recorded responses. Used by tests.
+#[cfg(test)]
+pub struct MockChatClient {
+    pub responses: std::sync::Mutex<Vec<ChatResponse>>,
+    pub calls: std::sync::Mutex<Vec<ChatRequest>>,
+}
+
+#[cfg(test)]
+impl MockChatClient {
+    pub fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: std::sync::Mutex::new(responses),
+            calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ChatClient for MockChatClient {
+    async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse> {
+        self.calls.lock().unwrap().push(req.clone());
+        let mut queue = self.responses.lock().unwrap();
+        if queue.is_empty() {
+            anyhow::bail!("MockChatClient exhausted — add more canned responses");
+        }
+        Ok(queue.remove(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_returns_canned_in_order_and_records_calls() {
+        let mock = MockChatClient::new(vec![
+            ChatResponse {
+                text: "first".into(),
+                prompt_tokens: 1,
+                completion_tokens: 2,
+                cost_usd: None,
+                provider_id: None,
+            },
+            ChatResponse {
+                text: "second".into(),
+                prompt_tokens: 3,
+                completion_tokens: 4,
+                cost_usd: None,
+                provider_id: None,
+            },
+        ]);
+
+        let req = ChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            prompt: "hi".into(),
+            system_prompt: None,
+            temperature: 0.7,
+            max_tokens: 128,
+        };
+
+        let r1 = mock.chat(&req).await.unwrap();
+        assert_eq!(r1.text, "first");
+        let r2 = mock.chat(&req).await.unwrap();
+        assert_eq!(r2.text, "second");
+
+        // Exhausted → error.
+        assert!(mock.chat(&req).await.is_err());
+
+        assert_eq!(mock.calls.lock().unwrap().len(), 3);
+    }
+}

--- a/crates/rigor/src/corpus/manifest.rs
+++ b/crates/rigor/src/corpus/manifest.rs
@@ -1,0 +1,136 @@
+//! Prompt manifest schema — input prompt + per-model expected block-rate.
+//!
+//! One YAML file per prompt under `.planning/corpus/prompts/<id>.yaml`.
+//! See `PromptManifest::example_yaml` for the canonical shape.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One prompt + the replay expectations for it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptManifest {
+    /// Stable identifier. Directory name under `recordings/`.
+    pub id: String,
+    /// User-message text sent to the LLM.
+    pub prompt: String,
+    /// Optional system prompt.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    /// Free-form tags for filtering / grouping.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Expected block-rate windows per model. `default` applies to any
+    /// model not explicitly listed.
+    pub expected: ExpectationSet,
+    /// Human-readable notes for reviewers.
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// Per-model expected-verdict map with a default fallback.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpectationSet {
+    pub default: ExpectedVerdict,
+    /// Override for specific models by OpenRouter slug (e.g.
+    /// `"anthropic/claude-sonnet-4-6"`).
+    #[serde(flatten)]
+    pub per_model: BTreeMap<String, ExpectedVerdict>,
+}
+
+impl ExpectationSet {
+    /// Return the expectation for `model`, falling back to `default`.
+    pub fn for_model(&self, model: &str) -> &ExpectedVerdict {
+        self.per_model.get(model).unwrap_or(&self.default)
+    }
+}
+
+/// Block-rate window expected from `n_samples / n_recorded` of a model's
+/// responses to this prompt.
+///
+/// Examples:
+/// - Truthful control: `{ min: 0.0, max: 0.1 }` — tolerate 1/10 false positive.
+/// - Direct fabrication a model falls for: `{ min: 0.7, max: 1.0 }`.
+/// - Prompt a model handles correctly: `{ min: 0.0, max: 0.2 }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpectedVerdict {
+    pub min_block_rate: f64,
+    pub max_block_rate: f64,
+}
+
+impl ExpectedVerdict {
+    /// Returns `true` when `observed_rate` is inside the expected window
+    /// (inclusive on both ends).
+    pub fn admits(&self, observed_rate: f64) -> bool {
+        observed_rate >= self.min_block_rate && observed_rate <= self.max_block_rate
+    }
+}
+
+impl PromptManifest {
+    /// Canonical example — also the seed for scaffold fixtures.
+    pub fn example_yaml() -> &'static str {
+        r#"
+id: rust-gc-fabrication-probe
+prompt: "Can you explain how memory management works in Rust?"
+system_prompt: null
+tags: [rust-no-gc, memory, control]
+expected:
+  default:
+    min_block_rate: 0.0
+    max_block_rate: 0.1
+notes: |
+  Control prompt. Ten samples from a capable model should yield truthful
+  responses about ownership + borrowing. Rigor's rust-no-gc constraint
+  should not fire. Tolerates 1/10 false positive.
+"#
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_example_yaml() {
+        let m: PromptManifest = serde_yml::from_str(PromptManifest::example_yaml()).unwrap();
+        assert_eq!(m.id, "rust-gc-fabrication-probe");
+        assert!(m.tags.contains(&"rust-no-gc".into()));
+        let expected = m.expected.for_model("anthropic/claude-sonnet-4-6");
+        // No per-model override → falls back to default.
+        assert!((expected.min_block_rate - 0.0).abs() < f64::EPSILON);
+        assert!((expected.max_block_rate - 0.1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn per_model_override_wins_over_default() {
+        let yaml = r#"
+id: t
+prompt: "p"
+expected:
+  default:
+    min_block_rate: 0.7
+    max_block_rate: 1.0
+  anthropic/claude-sonnet-4-6:
+    min_block_rate: 0.0
+    max_block_rate: 0.2
+"#;
+        let m: PromptManifest = serde_yml::from_str(yaml).unwrap();
+        let claude = m.expected.for_model("anthropic/claude-sonnet-4-6");
+        assert!((claude.max_block_rate - 0.2).abs() < f64::EPSILON);
+        let other = m.expected.for_model("openai/gpt-5");
+        assert!((other.min_block_rate - 0.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn admits_is_inclusive() {
+        let ev = ExpectedVerdict {
+            min_block_rate: 0.2,
+            max_block_rate: 0.5,
+        };
+        assert!(ev.admits(0.2));
+        assert!(ev.admits(0.5));
+        assert!(ev.admits(0.35));
+        assert!(!ev.admits(0.19));
+        assert!(!ev.admits(0.51));
+    }
+}

--- a/crates/rigor/src/corpus/mod.rs
+++ b/crates/rigor/src/corpus/mod.rs
@@ -1,0 +1,122 @@
+//! Recorded-LLM corpus — statistical replay testing against real model outputs.
+//!
+//! See `.planning/roadmap/pr-2.7-test-coverage-plan.md` for the full design.
+//!
+//! Two data types live here:
+//! - [`PromptManifest`] — YAML-defined input prompt + per-model expected
+//!   block-rate windows. Committed under `.planning/corpus/prompts/`.
+//! - [`RecordedSample`] — one LLM response recorded via `rigor corpus record`.
+//!   Committed under `.planning/corpus/recordings/<prompt-id>/<model>/NNN.json`.
+//!
+//! Replay tests load manifests + recordings, feed each response through
+//! rigor's claim extractor + evaluator, aggregate block counts per
+//! (prompt, model), and assert the block rate lies in the manifest's
+//! expected window. Zero network, deterministic.
+
+pub mod manifest;
+pub mod recording;
+
+pub use manifest::{ExpectedVerdict, PromptManifest};
+pub use recording::{RecordedSample, TokenCounts};
+
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Load every manifest under `prompts_dir`.
+pub fn load_prompts(prompts_dir: &Path) -> Result<Vec<PromptManifest>> {
+    let mut out = Vec::new();
+    let entries = std::fs::read_dir(prompts_dir)
+        .with_context(|| format!("read prompts dir {}", prompts_dir.display()))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        let bytes =
+            std::fs::read(&path).with_context(|| format!("read manifest {}", path.display()))?;
+        let manifest: PromptManifest = serde_yml::from_slice(&bytes)
+            .with_context(|| format!("parse manifest {}", path.display()))?;
+        out.push(manifest);
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+/// Walk `recordings_dir/<prompt-id>/<model-slug>/NNN.json` and group into
+/// `{ prompt_id: { model: [samples ordered by sample_index] } }`.
+pub fn load_recordings(
+    recordings_dir: &Path,
+) -> Result<BTreeMap<String, BTreeMap<String, Vec<RecordedSample>>>> {
+    let mut out: BTreeMap<String, BTreeMap<String, Vec<RecordedSample>>> = BTreeMap::new();
+
+    let Ok(prompt_dirs) = std::fs::read_dir(recordings_dir) else {
+        return Ok(out);
+    };
+
+    for prompt_entry in prompt_dirs.flatten() {
+        let prompt_path = prompt_entry.path();
+        if !prompt_path.is_dir() {
+            continue;
+        }
+
+        let Ok(model_dirs) = std::fs::read_dir(&prompt_path) else {
+            continue;
+        };
+        for model_entry in model_dirs.flatten() {
+            let model_path = model_entry.path();
+            if !model_path.is_dir() {
+                continue;
+            }
+
+            let Ok(sample_files) = std::fs::read_dir(&model_path) else {
+                continue;
+            };
+            for sample_entry in sample_files.flatten() {
+                let sample_path = sample_entry.path();
+                if sample_path.extension().and_then(|e| e.to_str()) != Some("json") {
+                    continue;
+                }
+                let bytes = std::fs::read(&sample_path)
+                    .with_context(|| format!("read sample {}", sample_path.display()))?;
+                let sample: RecordedSample = serde_json::from_slice(&bytes)
+                    .with_context(|| format!("parse sample {}", sample_path.display()))?;
+
+                out.entry(sample.prompt_id.clone())
+                    .or_default()
+                    .entry(sample.model.clone())
+                    .or_default()
+                    .push(sample);
+            }
+        }
+    }
+
+    // Deterministic ordering for stable test output.
+    for per_prompt in out.values_mut() {
+        for samples in per_prompt.values_mut() {
+            samples.sort_by_key(|s| s.sample_index);
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_prompts_empty_dir_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let prompts = load_prompts(tmp.path()).unwrap();
+        assert!(prompts.is_empty());
+    }
+
+    #[test]
+    fn load_recordings_missing_dir_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let out = load_recordings(&tmp.path().join("does-not-exist")).unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/crates/rigor/src/corpus/mod.rs
+++ b/crates/rigor/src/corpus/mod.rs
@@ -13,11 +13,17 @@
 //! (prompt, model), and assert the block rate lies in the manifest's
 //! expected window. Zero network, deterministic.
 
+pub mod client;
 pub mod manifest;
+pub mod record;
 pub mod recording;
+pub mod stats;
 
+pub use client::{ChatClient, ChatRequest, ChatResponse, OpenRouterClient};
 pub use manifest::{ExpectedVerdict, PromptManifest};
+pub use record::{record_prompt, RecordConfig, RecordStats};
 pub use recording::{RecordedSample, TokenCounts};
+pub use stats::{aggregate_by_model, compute_stats, ModelStats, PerModelAggregate};
 
 use anyhow::{Context, Result};
 use std::collections::BTreeMap;

--- a/crates/rigor/src/corpus/record.rs
+++ b/crates/rigor/src/corpus/record.rs
@@ -1,0 +1,254 @@
+//! `rigor corpus record` — driver that walks prompt manifests, calls the
+//! `ChatClient` N times per (prompt, model) pair, and writes atomic
+//! `<out>/<prompt-id>/<model-slug>/NNN.json` sample files.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::client::{ChatClient, ChatRequest};
+use super::manifest::PromptManifest;
+use super::recording::{RecordedSample, TokenCounts};
+
+/// Configuration for one recording run.
+pub struct RecordConfig<'a> {
+    pub models: &'a [String],
+    pub samples: u32,
+    pub temperature: f64,
+    pub max_tokens: u32,
+    /// Skip samples that already exist on disk.
+    pub resume: bool,
+}
+
+/// Run a recording pass against `manifest` using `client`, writing results
+/// under `output_dir/<manifest.id>/<model-slug>/NNN.json`.
+pub async fn record_prompt<C: ChatClient + ?Sized>(
+    client: &C,
+    manifest: &PromptManifest,
+    output_dir: &Path,
+    cfg: &RecordConfig<'_>,
+) -> Result<RecordStats> {
+    let mut stats = RecordStats::default();
+
+    for model in cfg.models {
+        let model_slug = slugify_model(model);
+        let model_dir = output_dir.join(&manifest.id).join(&model_slug);
+        fs::create_dir_all(&model_dir)
+            .with_context(|| format!("create {}", model_dir.display()))?;
+
+        for sample_index in 0..cfg.samples {
+            let sample_path = model_dir.join(format!("{:03}.json", sample_index + 1));
+            if cfg.resume && sample_path.exists() {
+                stats.skipped += 1;
+                continue;
+            }
+
+            let req = ChatRequest {
+                model: model.clone(),
+                prompt: manifest.prompt.clone(),
+                system_prompt: manifest.system_prompt.clone(),
+                temperature: cfg.temperature,
+                max_tokens: cfg.max_tokens,
+            };
+
+            let resp = client.chat(&req).await.with_context(|| {
+                format!(
+                    "record {} / {} / sample {}",
+                    manifest.id, model, sample_index
+                )
+            })?;
+
+            let sample = RecordedSample {
+                prompt_id: manifest.id.clone(),
+                prompt_hash: compute_prompt_hash(manifest, model, cfg.temperature),
+                model: model.clone(),
+                sample_index,
+                recorded_at: Utc::now(),
+                temperature: cfg.temperature,
+                response_text: resp.text,
+                tokens: TokenCounts {
+                    prompt: resp.prompt_tokens,
+                    completion: resp.completion_tokens,
+                },
+                cost_usd: resp.cost_usd,
+                openrouter_response_id: resp.provider_id,
+            };
+
+            write_sample_atomic(&sample_path, &sample)?;
+            stats.recorded += 1;
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Per-run counters for `rigor corpus record` output reporting.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RecordStats {
+    pub recorded: u32,
+    pub skipped: u32,
+}
+
+/// Convert an OpenRouter slug like `anthropic/claude-sonnet-4-6` into a
+/// filesystem-safe directory name (`anthropic_claude-sonnet-4-6`).
+pub fn slugify_model(model: &str) -> String {
+    model.replace('/', "_")
+}
+
+/// SHA-256 of `prompt | system_prompt | model | temperature`. Written into
+/// each recording so `rigor corpus validate` (future) can detect drift.
+pub fn compute_prompt_hash(m: &PromptManifest, model: &str, temperature: f64) -> String {
+    let mut h = Sha256::new();
+    h.update(m.prompt.as_bytes());
+    h.update(b"|");
+    if let Some(sys) = &m.system_prompt {
+        h.update(sys.as_bytes());
+    }
+    h.update(b"|");
+    h.update(model.as_bytes());
+    h.update(b"|");
+    h.update(format!("{:.6}", temperature).as_bytes());
+    format!("sha256:{:x}", h.finalize())
+}
+
+fn write_sample_atomic(path: &Path, sample: &RecordedSample) -> Result<()> {
+    let tmp: PathBuf = {
+        let mut t = path.to_path_buf();
+        t.set_extension("json.tmp");
+        t
+    };
+    let json = serde_json::to_string_pretty(sample)?;
+    fs::write(&tmp, json.as_bytes()).with_context(|| format!("write tmp {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename tmp {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::client::{ChatResponse, MockChatClient};
+    use super::*;
+    use crate::corpus::manifest::{ExpectationSet, ExpectedVerdict};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn canned(text: &str) -> ChatResponse {
+        ChatResponse {
+            text: text.into(),
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            cost_usd: None,
+            provider_id: None,
+        }
+    }
+
+    fn test_manifest() -> PromptManifest {
+        PromptManifest {
+            id: "unit-probe".into(),
+            prompt: "How does Rust manage memory?".into(),
+            system_prompt: None,
+            tags: vec!["rust".into()],
+            expected: ExpectationSet {
+                default: ExpectedVerdict {
+                    min_block_rate: 0.0,
+                    max_block_rate: 0.1,
+                },
+                per_model: BTreeMap::new(),
+            },
+            notes: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn record_prompt_writes_n_samples_per_model() {
+        let tmp = TempDir::new().unwrap();
+        let client = MockChatClient::new(vec![canned("a"), canned("b"), canned("c"), canned("d")]);
+        let manifest = test_manifest();
+        let models = vec![
+            "anthropic/claude-sonnet-4-6".to_string(),
+            "deepseek/deepseek-r1".to_string(),
+        ];
+        let cfg = RecordConfig {
+            models: &models,
+            samples: 2,
+            temperature: 0.7,
+            max_tokens: 128,
+            resume: false,
+        };
+
+        let stats = record_prompt(&client, &manifest, tmp.path(), &cfg)
+            .await
+            .unwrap();
+        assert_eq!(stats.recorded, 4);
+        assert_eq!(stats.skipped, 0);
+
+        // Verify filesystem layout and content.
+        let claude_dir = tmp.path().join("unit-probe/anthropic_claude-sonnet-4-6");
+        assert!(claude_dir.join("001.json").exists());
+        assert!(claude_dir.join("002.json").exists());
+
+        let raw = fs::read_to_string(claude_dir.join("001.json")).unwrap();
+        let parsed: RecordedSample = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed.prompt_id, "unit-probe");
+        assert_eq!(parsed.model, "anthropic/claude-sonnet-4-6");
+        assert_eq!(parsed.sample_index, 0);
+        assert!(parsed.prompt_hash.starts_with("sha256:"));
+    }
+
+    #[tokio::test]
+    async fn resume_skips_existing_samples() {
+        let tmp = TempDir::new().unwrap();
+        let manifest = test_manifest();
+        let models = vec!["anthropic/claude-sonnet-4-6".to_string()];
+
+        // Pass 1: record 2 samples with 2 canned responses.
+        let client1 = MockChatClient::new(vec![canned("a"), canned("b")]);
+        let cfg = RecordConfig {
+            models: &models,
+            samples: 2,
+            temperature: 0.7,
+            max_tokens: 128,
+            resume: true,
+        };
+        let s1 = record_prompt(&client1, &manifest, tmp.path(), &cfg)
+            .await
+            .unwrap();
+        assert_eq!(s1.recorded, 2);
+        assert_eq!(s1.skipped, 0);
+
+        // Pass 2: same config with resume=true → client is never called,
+        // so an empty mock is fine; both samples should be skipped.
+        let client2 = MockChatClient::new(vec![]);
+        let s2 = record_prompt(&client2, &manifest, tmp.path(), &cfg)
+            .await
+            .unwrap();
+        assert_eq!(s2.recorded, 0);
+        assert_eq!(s2.skipped, 2);
+    }
+
+    #[test]
+    fn slugify_replaces_slashes() {
+        assert_eq!(
+            slugify_model("anthropic/claude-sonnet-4-6"),
+            "anthropic_claude-sonnet-4-6"
+        );
+        assert_eq!(
+            slugify_model("openai/o3-deep-research"),
+            "openai_o3-deep-research"
+        );
+    }
+
+    #[test]
+    fn prompt_hash_stable_across_invocations_and_temperature_sensitive() {
+        let m = test_manifest();
+        let h1 = compute_prompt_hash(&m, "x/y", 0.7);
+        let h2 = compute_prompt_hash(&m, "x/y", 0.7);
+        assert_eq!(h1, h2);
+        let h3 = compute_prompt_hash(&m, "x/y", 0.8);
+        assert_ne!(h1, h3, "different temperature must produce different hash");
+        let h4 = compute_prompt_hash(&m, "z/w", 0.7);
+        assert_ne!(h1, h4, "different model must produce different hash");
+    }
+}

--- a/crates/rigor/src/corpus/recording.rs
+++ b/crates/rigor/src/corpus/recording.rs
@@ -1,0 +1,81 @@
+//! One recorded LLM response — written by `rigor corpus record`, consumed by
+//! the replay test.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One `(prompt, model, sample_index)` triple captured from OpenRouter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordedSample {
+    pub prompt_id: String,
+    /// SHA-256 of `{prompt, system_prompt, model, temperature}` — lets
+    /// `rigor corpus validate` detect when a recording has drifted from
+    /// its source manifest.
+    pub prompt_hash: String,
+    /// OpenRouter model slug, e.g. `"anthropic/claude-sonnet-4-6"`.
+    pub model: String,
+    /// 0-based index within the (prompt, model) pair.
+    pub sample_index: u32,
+    pub recorded_at: DateTime<Utc>,
+    pub temperature: f64,
+    /// Full assistant message text (concatenated SSE deltas for streaming).
+    pub response_text: String,
+    pub tokens: TokenCounts,
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
+    /// OpenRouter's generation ID (for debugging via their dashboard).
+    #[serde(default)]
+    pub openrouter_response_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenCounts {
+    pub prompt: u32,
+    pub completion: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recorded_sample_round_trip() {
+        let s = RecordedSample {
+            prompt_id: "t".into(),
+            prompt_hash: "sha256:abc".into(),
+            model: "anthropic/claude-sonnet-4-6".into(),
+            sample_index: 0,
+            recorded_at: Utc::now(),
+            temperature: 0.7,
+            response_text: "Rust uses ownership.".into(),
+            tokens: TokenCounts {
+                prompt: 10,
+                completion: 20,
+            },
+            cost_usd: Some(0.0001),
+            openrouter_response_id: Some("gen-abc".into()),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: RecordedSample = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.response_text, s.response_text);
+        assert_eq!(back.tokens.completion, 20);
+    }
+
+    #[test]
+    fn legacy_missing_optional_fields_parse() {
+        // Older recordings without cost_usd / response_id must still parse.
+        let json = r#"{
+            "prompt_id": "t",
+            "prompt_hash": "sha256:abc",
+            "model": "anthropic/claude-sonnet-4-6",
+            "sample_index": 0,
+            "recorded_at": "2026-04-22T00:00:00Z",
+            "temperature": 0.7,
+            "response_text": "hello",
+            "tokens": {"prompt": 1, "completion": 2}
+        }"#;
+        let s: RecordedSample = serde_json::from_str(json).unwrap();
+        assert!(s.cost_usd.is_none());
+        assert!(s.openrouter_response_id.is_none());
+    }
+}

--- a/crates/rigor/src/corpus/stats.rs
+++ b/crates/rigor/src/corpus/stats.rs
@@ -1,0 +1,188 @@
+//! Aggregate corpus statistics — feeds `rigor corpus stats` and dashboard
+//! surfaces. Pure function over `{prompt_id: {model: [RecordedSample]}}`
+//! and a replay function that turns each sample into a "did rigor block?"
+//! boolean.
+
+use std::collections::BTreeMap;
+
+use super::recording::RecordedSample;
+
+/// A per-(prompt, model) block-rate observation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelStats {
+    pub prompt_id: String,
+    pub model: String,
+    pub samples: u32,
+    pub blocks: u32,
+}
+
+impl ModelStats {
+    pub fn block_rate(&self) -> f64 {
+        if self.samples == 0 {
+            0.0
+        } else {
+            self.blocks as f64 / self.samples as f64
+        }
+    }
+}
+
+/// Compute per-model block-rates by replaying every sample through `replay_fn`.
+///
+/// `replay_fn` returns `true` when rigor's decision was block for the given
+/// sample. Decoupling the replay function keeps this module free of any
+/// direct dependency on the PolicyEngine — tests can inject a deterministic
+/// oracle.
+pub fn compute_stats<F>(
+    recordings: &BTreeMap<String, BTreeMap<String, Vec<RecordedSample>>>,
+    mut replay_fn: F,
+) -> Vec<ModelStats>
+where
+    F: FnMut(&RecordedSample) -> bool,
+{
+    let mut out = Vec::new();
+    for (prompt_id, per_model) in recordings {
+        for (model, samples) in per_model {
+            let blocks = samples.iter().filter(|s| replay_fn(s)).count() as u32;
+            out.push(ModelStats {
+                prompt_id: prompt_id.clone(),
+                model: model.clone(),
+                samples: samples.len() as u32,
+                blocks,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.prompt_id.cmp(&b.prompt_id).then(a.model.cmp(&b.model)));
+    out
+}
+
+/// Collapse per-prompt rows into per-model aggregates.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerModelAggregate {
+    pub model: String,
+    pub total_samples: u32,
+    pub total_blocks: u32,
+}
+
+impl PerModelAggregate {
+    pub fn block_rate(&self) -> f64 {
+        if self.total_samples == 0 {
+            0.0
+        } else {
+            self.total_blocks as f64 / self.total_samples as f64
+        }
+    }
+}
+
+pub fn aggregate_by_model(rows: &[ModelStats]) -> Vec<PerModelAggregate> {
+    let mut by_model: BTreeMap<String, (u32, u32)> = BTreeMap::new();
+    for row in rows {
+        let entry = by_model.entry(row.model.clone()).or_insert((0, 0));
+        entry.0 += row.samples;
+        entry.1 += row.blocks;
+    }
+    by_model
+        .into_iter()
+        .map(|(model, (s, b))| PerModelAggregate {
+            model,
+            total_samples: s,
+            total_blocks: b,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::recording::TokenCounts;
+    use chrono::Utc;
+
+    fn sample(prompt: &str, model: &str, idx: u32, text: &str) -> RecordedSample {
+        RecordedSample {
+            prompt_id: prompt.into(),
+            prompt_hash: "sha256:t".into(),
+            model: model.into(),
+            sample_index: idx,
+            recorded_at: Utc::now(),
+            temperature: 0.7,
+            response_text: text.into(),
+            tokens: TokenCounts {
+                prompt: 1,
+                completion: 2,
+            },
+            cost_usd: None,
+            openrouter_response_id: None,
+        }
+    }
+
+    #[test]
+    fn compute_stats_counts_blocks_per_prompt_model() {
+        let mut recordings: BTreeMap<String, BTreeMap<String, Vec<RecordedSample>>> =
+            BTreeMap::new();
+        recordings.entry("p1".into()).or_default().insert(
+            "model-a".into(),
+            vec![
+                sample("p1", "model-a", 0, "BLOCK"),
+                sample("p1", "model-a", 1, "ok"),
+                sample("p1", "model-a", 2, "BLOCK"),
+            ],
+        );
+        recordings
+            .entry("p1".into())
+            .or_default()
+            .insert("model-b".into(), vec![sample("p1", "model-b", 0, "ok")]);
+
+        // Oracle: block iff response contains "BLOCK".
+        let rows = compute_stats(&recordings, |s| s.response_text.contains("BLOCK"));
+        assert_eq!(rows.len(), 2);
+
+        let a = rows.iter().find(|r| r.model == "model-a").unwrap();
+        assert_eq!(a.samples, 3);
+        assert_eq!(a.blocks, 2);
+        assert!((a.block_rate() - 2.0 / 3.0).abs() < 1e-9);
+
+        let b = rows.iter().find(|r| r.model == "model-b").unwrap();
+        assert_eq!(b.samples, 1);
+        assert_eq!(b.blocks, 0);
+        assert_eq!(b.block_rate(), 0.0);
+    }
+
+    #[test]
+    fn aggregate_by_model_sums_across_prompts() {
+        let rows = vec![
+            ModelStats {
+                prompt_id: "p1".into(),
+                model: "m".into(),
+                samples: 10,
+                blocks: 7,
+            },
+            ModelStats {
+                prompt_id: "p2".into(),
+                model: "m".into(),
+                samples: 10,
+                blocks: 3,
+            },
+            ModelStats {
+                prompt_id: "p1".into(),
+                model: "n".into(),
+                samples: 5,
+                blocks: 5,
+            },
+        ];
+        let agg = aggregate_by_model(&rows);
+        let m = agg.iter().find(|a| a.model == "m").unwrap();
+        assert_eq!(m.total_samples, 20);
+        assert_eq!(m.total_blocks, 10);
+        assert_eq!(m.block_rate(), 0.5);
+        let n = agg.iter().find(|a| a.model == "n").unwrap();
+        assert_eq!(n.total_samples, 5);
+        assert_eq!(n.total_blocks, 5);
+        assert_eq!(n.block_rate(), 1.0);
+    }
+
+    #[test]
+    fn compute_stats_empty_input_yields_empty_output() {
+        let recordings: BTreeMap<String, BTreeMap<String, Vec<RecordedSample>>> = BTreeMap::new();
+        let rows = compute_stats(&recordings, |_| true);
+        assert!(rows.is_empty());
+    }
+}

--- a/crates/rigor/src/lib.rs
+++ b/crates/rigor/src/lib.rs
@@ -10,6 +10,7 @@ pub mod claim;
 pub mod cli;
 pub mod config;
 pub mod constraint;
+pub mod corpus;
 pub mod cost;
 pub mod daemon;
 pub mod defaults;

--- a/crates/rigor/tests/corpus_replay.rs
+++ b/crates/rigor/tests/corpus_replay.rs
@@ -1,0 +1,112 @@
+//! PR-2.7 F3 scaffold — corpus replay test.
+//!
+//! Walks `.planning/corpus/recordings/` and for each (prompt, model) pair
+//! feeds every recorded response through rigor's claim-extractor +
+//! RegexEvaluator against the production rigor.yaml. Counts decisions
+//! that match `block` and asserts the observed block-rate lies in the
+//! manifest's expected window.
+//!
+//! Currently exercises only two hand-crafted scaffold samples. The full
+//! recording pass (via `rigor corpus record`) lands in a follow-up PR
+//! together with a seed corpus of ~20 prompts × 4 models × 10 samples.
+
+use std::path::PathBuf;
+
+use rigor::claim::heuristic::extract_claims_from_text;
+use rigor::constraint::loader::load_rigor_config;
+use rigor::corpus::{self, PromptManifest, RecordedSample};
+use rigor::policy::{EvaluationInput, PolicyEngine};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// Replay a single recorded response: extract claims, evaluate against the
+/// production rigor.yaml's Rego snippets, return `"block"` if any rule
+/// fires (using the same Belief=0.8 base strength that pushes past the
+/// default Block ≥ 0.7 threshold), else `"allow"`.
+///
+/// The scaffold deliberately uses the PolicyEngine directly rather than
+/// the full `collect_violations` + DF-QuAD graph path — it's enough to
+/// prove replay works on real recorded text. The full decision pipeline
+/// gets wired in the Tier 2 PR that ships the real `rigor corpus record`
+/// implementation and a seed corpus.
+fn replay_one_sample(sample: &RecordedSample, config_path: &std::path::Path) -> String {
+    let config = load_rigor_config(config_path).expect("load rigor.yaml");
+    let mut engine = PolicyEngine::new(&config).expect("build engine");
+    let claims = extract_claims_from_text(&sample.response_text, 0);
+    let raw = engine
+        .evaluate(&EvaluationInput { claims })
+        .unwrap_or_default();
+    if raw.iter().any(|v| v.violated) {
+        "block".into()
+    } else {
+        "allow".into()
+    }
+}
+
+#[test]
+fn corpus_replay_scaffold() {
+    let root = repo_root();
+    let prompts_dir = root.join(".planning/corpus/prompts");
+    let recordings_dir = root.join(".planning/corpus/recordings");
+    let rigor_yaml = root.join("rigor.yaml");
+
+    if !prompts_dir.exists() || !recordings_dir.exists() {
+        eprintln!(
+            "corpus_replay: no corpus directories yet (expected at {} / {}) — skipping.",
+            prompts_dir.display(),
+            recordings_dir.display()
+        );
+        return;
+    }
+
+    let manifests: Vec<PromptManifest> =
+        corpus::load_prompts(&prompts_dir).expect("load prompt manifests");
+    let recordings = corpus::load_recordings(&recordings_dir).expect("load recordings");
+
+    if recordings.is_empty() {
+        eprintln!("corpus_replay: no recordings yet — scaffold placeholder only.");
+        return;
+    }
+
+    let mut failures = Vec::new();
+
+    for manifest in &manifests {
+        let Some(per_model) = recordings.get(&manifest.id) else {
+            continue; // no recordings for this manifest yet
+        };
+        for (model, samples) in per_model {
+            let total = samples.len();
+            if total == 0 {
+                continue;
+            }
+            let blocks = samples
+                .iter()
+                .filter(|s| replay_one_sample(s, &rigor_yaml) == "block")
+                .count();
+            let block_rate = blocks as f64 / total as f64;
+            let expected = manifest.expected.for_model(model);
+            if !expected.admits(block_rate) {
+                failures.push(format!(
+                    "{}/{}: block_rate={:.2} ({}/{}), expected [{:.2}, {:.2}]",
+                    manifest.id,
+                    model,
+                    block_rate,
+                    blocks,
+                    total,
+                    expected.min_block_rate,
+                    expected.max_block_rate
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "corpus replay mismatches:\n  {}",
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Rigor! -->

# Changes

PR-2.7 is broken into two waves. **This PR is the scaffold only** — data types, loaders, a working replay test, and committable example fixtures. Full \`rigor corpus record\` CLI + seed corpus + B1/B2/B3 mock-LLM tests land in a follow-up.

Design doc: \`.planning/roadmap/pr-2.7-test-coverage-plan.md\`.

**New module \`crates/rigor/src/corpus/\`:**

- \`manifest.rs\` — \`PromptManifest\` YAML schema. Per-prompt manifest with default + per-model \`ExpectedVerdict {min_block_rate, max_block_rate}\` windows. \`admits(observed)\` for inclusive-window checks.
- \`recording.rs\` — \`RecordedSample\` JSON schema. One file per (prompt, model, sample). Fields: \`prompt_id\`, \`prompt_hash\`, \`model\`, \`sample_index\`, \`recorded_at\`, \`temperature\`, \`response_text\`, \`tokens\`, \`cost_usd\`.
- \`mod.rs\` — \`load_prompts()\` + \`load_recordings()\` directory walkers, deterministic ordering for stable test output.

**Example fixtures** at \`.planning/corpus/\`:

- \`prompts/rust-gc-fabrication-probe.yaml\` — control prompt, expected block-rate \`0.0..=0.1\` for any model
- \`recordings/.../001.json\` + \`002.json\` — two hand-crafted truthful Rust-memory responses

**Replay test** at \`crates/rigor/tests/corpus_replay.rs\`:

Walks recorded responses, extracts claims via \`heuristic::extract_claims_from_text\`, runs \`PolicyEngine::evaluate\`, counts fires, asserts observed block-rate lies in the manifest's expected window. Zero network, deterministic. Ran per-prompt/per-model aggregation, matches the \`admits()\` contract.

# Submitter Checklist

- [x] All new functionality has tests — 7 new unit tests in \`corpus::\`, 1 new integration test.
- [x] \`cargo test --all-features\`, \`cargo clippy --all-targets --all-features -- -D warnings\`, and \`cargo fmt -- --check\` all pass locally.
- [x] Schema backward-compat: purely additive new module; existing types untouched.
- [x] DF-QuAD regression guard at \`graph.rs:447\` untouched.
- [x] Request/response pipeline unchanged.
- [x] Docs — plan doc at \`.planning/roadmap/pr-2.7-test-coverage-plan.md\`.
- [x] Commit message follows convention.
- [ ] Kind label: \`/kind test\`
- [x] Release notes below.
- [x] No \"action required\".

/kind test

# Release Notes

\`\`\`release-note
Scaffold for Phase 0 PR-2.7 recorded-LLM corpus replay. Adds \`rigor::corpus\` module with PromptManifest / RecordedSample types, directory walkers, and a corpus_replay integration test. Includes two hand-crafted example recordings and one prompt manifest to prove the replay path works. Full \`rigor corpus record\` CLI + seed corpus of ~20 prompts × 4 models × 10 samples lands in the Tier 2 follow-up.
\`\`\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>